### PR TITLE
Add JWT auth middleware and login endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/server/middleware/auth.js
+++ b/src/server/middleware/auth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function authMiddleware(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ message: 'Accès non autorisé' });
+  }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Token invalide' });
+  }
+};


### PR DESCRIPTION
## Summary
- add JSON Web Token auth middleware
- add login endpoint and apply auth middleware to API routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689cbaac8c54832daaa612f2c4d08fd7