### PR TITLE
Hash API keys before storage

### DIFF
--- a/src/migrations/20250510200000-create-apikey-table.js
+++ b/src/migrations/20250510200000-create-apikey-table.js
@@ -14,10 +14,14 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: false
       },
-      key: {
+      key_hash: {
         type: Sequelize.STRING,
         allowNull: false,
         unique: true
+      },
+      key_last4: {
+        type: Sequelize.STRING(4),
+        allowNull: false
       },
       permissions: {
         type: Sequelize.JSON,

--- a/src/seeders/20250510200100-default-apikeys.js
+++ b/src/seeders/20250510200100-default-apikeys.js
@@ -3,39 +3,42 @@ const crypto = require('crypto');
 
 // Fonction pour générer une clé API
 const generateKey = () => 'sk_' + crypto.randomBytes(24).toString('hex');
+const hashKey = (key) => crypto.createHash('sha256').update(key).digest('hex');
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.bulkInsert('ApiKeys', [
+    const keys = [
       {
         name: 'Application mobile',
-        key: generateKey(),
         permissions: JSON.stringify(['read', 'write']),
         active: true,
-        description: 'Clé API pour l\'application mobile',
-        createdAt: new Date(),
-        updatedAt: new Date()
+        description: 'Clé API pour l\'application mobile'
       },
       {
         name: 'Intégration CRM',
-        key: generateKey(),
         permissions: JSON.stringify(['read']),
         active: false,
-        description: 'Clé API pour l\'intégration avec le CRM',
-        createdAt: new Date(),
-        updatedAt: new Date()
+        description: 'Clé API pour l\'intégration avec le CRM'
       },
       {
         name: 'Webhook externe',
-        key: generateKey(),
         permissions: JSON.stringify(['read', 'write', 'webhook']),
         active: true,
-        description: 'Clé API pour les webhooks externes',
+        description: 'Clé API pour les webhooks externes'
+      }
+    ].map(data => {
+      const key = generateKey();
+      return {
+        ...data,
+        key_hash: hashKey(key),
+        key_last4: key.slice(-4),
         createdAt: new Date(),
         updatedAt: new Date()
-      }
-    ], {});
+      };
+    });
+
+    await queryInterface.bulkInsert('ApiKeys', keys, {});
   },
 
   async down(queryInterface, Sequelize) {

--- a/src/server/api-routes.js
+++ b/src/server/api-routes.js
@@ -2482,12 +2482,11 @@ router.post('/apikeys', asyncHandler(async (req, res) => {
   const { name, permissions, active, expires_at, description } = req.body;
 
   // Générer une nouvelle clé API
-  const key = 'sk_' + crypto.randomBytes(24).toString('hex');
-
-  // Créer la clé API
+  const key = ApiKey.generateKey();
   const apiKey = await ApiKey.create({
     name,
-    key,
+    key_hash: ApiKey.hashKey(key),
+    key_last4: key.slice(-4),
     permissions: permissions || ['read'],
     active: active !== undefined ? active : true,
     expires_at: expires_at || null,
@@ -2498,7 +2497,7 @@ router.post('/apikeys', asyncHandler(async (req, res) => {
   const transformedApiKey = {
     id: apiKey.id.toString(),
     name: apiKey.name,
-    key: apiKey.key, // Renvoyer la clé complète lors de la création
+    key, // Renvoyer la clé complète lors de la création
     permissions: apiKey.permissions,
     active: apiKey.active,
     expires_at: apiKey.expires_at ? apiKey.expires_at.toISOString() : null,
@@ -2560,15 +2559,16 @@ router.post('/apikeys/:id/regenerate', asyncHandler(async (req, res) => {
   }
 
   // Générer une nouvelle clé API
-  const key = 'sk_' + crypto.randomBytes(24).toString('hex');
-  apiKey.key = key;
+  const key = ApiKey.generateKey();
+  apiKey.key_hash = ApiKey.hashKey(key);
+  apiKey.key_last4 = key.slice(-4);
   await apiKey.save();
 
   // Transformer les données
   const transformedApiKey = {
     id: apiKey.id.toString(),
     name: apiKey.name,
-    key: apiKey.key, // Renvoyer la clé complète lors de la régénération
+    key, // Renvoyer la clé complète lors de la régénération
     permissions: apiKey.permissions,
     active: apiKey.active,
     expires_at: apiKey.expires_at ? apiKey.expires_at.toISOString() : null,


### PR DESCRIPTION
## Summary
- hash API keys with SHA-256 and store only digest and last four characters
- expose raw key only at creation or regeneration
- add key verification helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689cbab0924c832d9ca16ad352a51b9e