### PR TITLE
feat: add database connection test and save

### DIFF
--- a/src/pages/settings/DatabaseSettings.tsx
+++ b/src/pages/settings/DatabaseSettings.tsx
@@ -4,6 +4,8 @@ import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
 import { Database, HardDrive, Server, RefreshCw, Archive } from 'lucide-react';
+import { useToast } from '../../components/ui/use-toast';
+import { SettingsService } from '../../services/settingsService.ts';
 
 const DatabaseSettings: React.FC = () => {
   const [connection, setConnection] = useState({
@@ -14,19 +16,45 @@ const DatabaseSettings: React.FC = () => {
     password: ''
   });
 
+  const { toast } = useToast();
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setConnection(prev => ({ ...prev, [name]: value }));
   };
 
-  const handleTestConnection = () => {
-    // TODO: Implémenter la logique de test de connexion
-    console.log('Test connection:', connection);
+  const handleTestConnection = async () => {
+    try {
+      await SettingsService.testDatabaseConnection(connection);
+      toast({
+        title: 'Connexion réussie',
+        description: 'La connexion à la base de données a été vérifiée avec succès.'
+      });
+    } catch (error) {
+      console.error('Erreur de test de connexion:', error);
+      toast({
+        title: 'Échec de la connexion',
+        description: 'Impossible de se connecter à la base de données.',
+        variant: 'destructive'
+      });
+    }
   };
 
-  const handleSave = () => {
-    // TODO: Implémenter la sauvegarde des paramètres
-    console.log('Save connection:', connection);
+  const handleSave = async () => {
+    try {
+      await SettingsService.saveSettings('database', connection);
+      toast({
+        title: 'Paramètres sauvegardés',
+        description: 'La configuration de la base de données a été enregistrée.'
+      });
+    } catch (error) {
+      console.error('Erreur lors de la sauvegarde:', error);
+      toast({
+        title: 'Erreur de sauvegarde',
+        description: "Impossible d'enregistrer les paramètres de la base de données.",
+        variant: 'destructive'
+      });
+    }
   };
 
   return (

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -59,6 +59,20 @@ export const SettingsService = {
   async getAllSettings(): Promise<Record<string, Settings>> {
     const response = await axios.get(`${API_BASE_URL}/settings`);
     return response.data as Record<string, Settings>;
+  },
+
+  /**
+   * Teste la connexion à la base de données
+   */
+  async testDatabaseConnection(connection: {
+    host: string;
+    port: string;
+    name: string;
+    user: string;
+    password: string;
+  }): Promise<{ success: boolean; message: string }> {
+    const response = await axios.post(`${API_BASE_URL}/settings/database/test`, connection);
+    return response.data as { success: boolean; message: string };
   }
 };
 


### PR DESCRIPTION
## Summary
- verify database connectivity via `SettingsService.testDatabaseConnection`
- persist database settings with `SettingsService.saveSettings`
- surface success or failure to the user using toast notifications

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: SyntaxError in eslint.config.js)

------
https://chatgpt.com/codex/tasks/task_e_689cc9449d38832dbbafcc10fbef32da