### PR TITLE
feat: add deep compare effect for reference data hooks

### DIFF
--- a/src/docs/REFERENCE_DATA_USAGE.md
+++ b/src/docs/REFERENCE_DATA_USAGE.md
@@ -123,6 +123,8 @@ function MyForm() {
 3. **Utiliser les composants de sélection** pour garantir une expérience utilisateur cohérente.
 4. **Utiliser les hooks personnalisés** pour simplifier l'accès aux données dans les composants React.
 5. **Utiliser le service centralisé** pour accéder aux données dans les services et les composants non-React.
+6. **Stabiliser les paramètres** transmis aux hooks (ex. `params`) en les mémoïsant
+   avec `useMemo` afin d'éviter des requêtes répétées inutiles.
 
 ## Exemple complet
 

--- a/src/hooks/useDeepCompareEffect.ts
+++ b/src/hooks/useDeepCompareEffect.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, EffectCallback } from 'react';
+
+function isObject(obj: unknown): obj is Record<string, any> {
+  return obj !== null && typeof obj === 'object';
+}
+
+function deepEqual(a: any, b: any): boolean {
+  if (Object.is(a, b)) return true;
+
+  if (!isObject(a) || !isObject(b)) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (keysA.length !== keysB.length) return false;
+
+  for (const key of keysA) {
+    if (!keysB.includes(key)) return false;
+    if (!deepEqual(a[key], b[key])) return false;
+  }
+
+  return true;
+}
+
+export function useDeepCompareEffect(effect: EffectCallback, dependencies: any[]) {
+  const previousDeps = useRef<any[]>([]);
+
+  if (!deepEqual(previousDeps.current, dependencies)) {
+    previousDeps.current = dependencies;
+  }
+
+  useEffect(effect, [previousDeps.current]);
+}

--- a/src/hooks/useReferenceData.ts
+++ b/src/hooks/useReferenceData.ts
@@ -2,13 +2,16 @@
  * Hooks personnalisés pour accéder aux données de référence
  * Ces hooks facilitent l'utilisation des données de référence dans les composants React
  */
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { useDeepCompareEffect } from './useDeepCompareEffect';
 import ReferenceDataService from '../services/ReferenceDataService';
 
 /**
  * Hook générique pour récupérer des données de référence
  * @param fetchFunction Fonction à appeler pour récupérer les données
- * @param params Paramètres optionnels pour la requête
+ * @param params Paramètres optionnels pour la requête. Pour éviter des
+ * rechargements inutiles, mémoïsez cet objet afin de garantir la stabilité de
+ * sa référence (ex. avec `useMemo`).
  * @param dependencies Dépendances supplémentaires pour le useEffect
  */
 export function useReferenceData<T>(
@@ -20,7 +23,7 @@ export function useReferenceData<T>(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
@@ -37,8 +40,7 @@ export function useReferenceData<T>(
     };
 
     fetchData();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(params), ...dependencies]);
+  }, [params, ...dependencies]);
 
   return { data, loading, error };
 }


### PR DESCRIPTION
## Summary
- implement a simple deep compare effect hook
- use the deep compare effect in reference data hooks and remove JSON.stringify
- document requirement to memoize params passed to reference data hooks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689cc9495db8832d8bb5a1a5ce715e8c