### PR TITLE
refactor: use centralized axios instance

### DIFF
--- a/src/services/ReferenceDataService.ts
+++ b/src/services/ReferenceDataService.ts
@@ -3,13 +3,13 @@
  * Ce service fournit des méthodes pour récupérer les données des tables de référence
  * comme les utilisateurs, pays, devises, langues, etc.
  */
-import axios from 'axios';
+import { api } from './api';
 
 class ReferenceDataService {
   // Méthodes génériques
   async getAll(endpoint: string, params = {}) {
     try {
-      const response = await axios.get(`/api/${endpoint}`, { params });
+      const response = await api.get(`/${endpoint}`, { params });
       return response.data;
     } catch (error) {
       console.error(`Erreur lors de la récupération des données depuis ${endpoint}:`, error);
@@ -19,7 +19,7 @@ class ReferenceDataService {
   
   async getById(endpoint: string, id: number | string) {
     try {
-      const response = await axios.get(`/api/${endpoint}/${id}`);
+      const response = await api.get(`/${endpoint}/${id}`);
       return response.data;
     } catch (error) {
       console.error(`Erreur lors de la récupération des données depuis ${endpoint}/${id}:`, error);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,11 +2,20 @@ import axios from 'axios';
 
 // Configuration de base d'axios
 const api = axios.create({
-  baseURL: 'http://164.160.40.182:3001/api',
+  baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
   headers: {
     'Content-Type': 'application/json',
   },
 });
+
+// Gestion globale des erreurs
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    console.error('Erreur API:', error);
+    return Promise.reject(error);
+  }
+);
 
 // Exporter api comme exportation nommée
 export { api };


### PR DESCRIPTION
## Summary
- add centralized axios instance with base URL and error logging
- refactor ReferenceDataService to use shared axios instance

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: ESLint config syntax error)


------
https://chatgpt.com/codex/tasks/task_e_689cc94f439c832da16c3933169f8e86