### PR TITLE
chore: rename package and update metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vite_react_shadcn_ts",
-  "version": "0.0.0",
+  "name": "entidr",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite_react_shadcn_ts",
-      "version": "0.0.0",
+      "name": "entidr",
+      "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "vite_react_shadcn_ts",
+  "name": "entidr",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "description": "Entidr application",
   "type": "commonjs",
   "scripts": {
     "generate-modules": "node scripts/generateModuleRegistry.js",


### PR DESCRIPTION
## Summary
- rename package to `entidr`
- set initial version and description metadata
- confirmed CommonJS module type for server code

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689d408cf25c832d967f1cf960943d93