### PR TITLE
chore: align modules settings api base url

### DIFF
--- a/src/components/settings/ModulesSettings.tsx
+++ b/src/components/settings/ModulesSettings.tsx
@@ -27,7 +27,9 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Loader2, Trash2, Power, RefreshCw } from 'lucide-react';
 import { Module } from '../../types/module';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://164.160.40.182:3001/api';
+// Utilise l'URL de base de l'API définie dans les variables d'environnement, avec un
+// repli local identique au reste du projet pour éviter toute adresse codée en dur.
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
 
 /**
  * Composant pour la gestion des modules


### PR DESCRIPTION
## Summary
- use same API base URL fallback in ModulesSettings as elsewhere

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: SyntaxError: Cannot use import statement outside a module)


------
https://chatgpt.com/codex/tasks/task_e_689de3baf018832d8b4cb00f60409bdc