### PR TITLE
use VITE_API_BASE_URL for API endpoint

### DIFF
--- a/README-DEMARRAGE.md
+++ b/README-DEMARRAGE.md
@@ -54,7 +54,7 @@ Les scripts effectuent les opérations suivantes dans l'ordre :
 Une fois les scripts exécutés avec succès, vous pouvez accéder à :
 
 - **Frontend** : [http://localhost:8080](http://localhost:8080)
-- **API** : [http://localhost:3001](http://localhost:3001)
+- **API** : définie par la variable `VITE_API_BASE_URL`
 
 ## Arrêt de l'Application
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm run dev
 
 Le projet nécessite certaines variables d'environnement pour fonctionner correctement. Vous pouvez utiliser le fichier `.env.example` comme base.
 
-- **VITE_API_BASE_URL** : URL de base de l'API utilisée par le front-end.
+- **VITE_API_BASE_URL** : URL de base de l'API utilisée par le front-end. Modifiez cette valeur dans `.env` pour changer l'URL cible.
 - **PORT** : Port d'écoute du serveur backend (optionnel, `3001` par défaut).
 - **DB_USERNAME** : Nom d'utilisateur de la base de données.
 - **DB_PASSWORD** : Mot de passe de la base de données.

--- a/src/components/settings/ModulesSettings.tsx
+++ b/src/components/settings/ModulesSettings.tsx
@@ -27,7 +27,10 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Loader2, Trash2, Power, RefreshCw } from 'lucide-react';
 import { Module } from '../../types/module';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://164.160.40.182:3001/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+if (!API_BASE_URL) {
+  throw new Error('VITE_API_BASE_URL is required');
+}
 
 /**
  * Composant pour la gestion des modules

--- a/src/pages/settings/CalendarSettings.tsx
+++ b/src/pages/settings/CalendarSettings.tsx
@@ -11,6 +11,11 @@ import { useToast } from '../../components/ui/use-toast';
 import { ConfirmationDialog } from '../../components/ui/confirmation-dialog';
 import axios from 'axios';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+if (!API_BASE_URL) {
+  throw new Error('VITE_API_BASE_URL is required');
+}
+
 interface Holiday {
   id: string;
   name: string;
@@ -97,7 +102,7 @@ const CalendarSettings: React.FC = () => {
         setLoading(true);
 
         // Récupérer la configuration du calendrier
-        const configResponse = await axios.get('http://164.160.40.182:3001/api/calendarconfig');
+        const configResponse = await axios.get(`${API_BASE_URL}/calendarconfig`);
         setCalendarConfig(configResponse.data);
         setTimezone(configResponse.data.timezone);
         setWorkHours({
@@ -107,11 +112,11 @@ const CalendarSettings: React.FC = () => {
         setWeekStart(configResponse.data.weekStart);
 
         // Récupérer les jours fériés
-        const holidaysResponse = await axios.get('http://164.160.40.182:3001/api/holidays');
+        const holidaysResponse = await axios.get(`${API_BASE_URL}/holidays`);
         setHolidays(holidaysResponse.data);
 
         // Récupérer les intégrations de calendrier
-        const integrationsResponse = await axios.get('http://164.160.40.182:3001/api/calendarintegrations');
+        const integrationsResponse = await axios.get(`${API_BASE_URL}/calendarintegrations`);
         setIntegrations(integrationsResponse.data);
 
         setLoading(false);
@@ -139,7 +144,7 @@ const CalendarSettings: React.FC = () => {
         weekStart
       };
 
-      await axios.put('http://164.160.40.182:3001/api/calendarconfig', updatedConfig);
+      await axios.put(`${API_BASE_URL}/calendarconfig`, updatedConfig);
       setCalendarConfig(updatedConfig);
 
       setLoading(false);
@@ -164,7 +169,7 @@ const CalendarSettings: React.FC = () => {
     try {
       setLoading(true);
 
-      const response = await axios.post('http://164.160.40.182:3001/api/holidays', newHoliday);
+      const response = await axios.post(`${API_BASE_URL}/holidays`, newHoliday);
       setHolidays([...holidays, response.data]);
 
       // Réinitialiser le formulaire et fermer la boîte de dialogue
@@ -209,7 +214,7 @@ const CalendarSettings: React.FC = () => {
     setIsDeleting(true);
 
     try {
-      await axios.delete(`http://164.160.40.182:3001/api/holidays/${holidayToDelete.id}`);
+      await axios.delete(`${API_BASE_URL}/holidays/${holidayToDelete.id}`);
 
       // Mettre à jour l'état local
       setHolidays(holidays.filter(h => h.id !== holidayToDelete.id));

--- a/src/pages/settings/NotificationSettings.tsx
+++ b/src/pages/settings/NotificationSettings.tsx
@@ -14,6 +14,11 @@ import { Checkbox } from '../../components/ui/checkbox';
 import { Alert, AlertDescription, AlertTitle } from '../../components/ui/alert';
 import axios from 'axios';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+if (!API_BASE_URL) {
+  throw new Error('VITE_API_BASE_URL is required');
+}
+
 // Types pour les notifications
 interface NotificationChannel {
   id: string;
@@ -149,23 +154,23 @@ const NotificationSettings: React.FC = () => {
         setLoading(true);
 
         // Récupérer les canaux de notification
-        const channelsResponse = await axios.get('http://164.160.40.182:3001/api/notificationchannels');
+        const channelsResponse = await axios.get(`${API_BASE_URL}/notificationchannels`);
         setChannels(channelsResponse.data);
 
         // Récupérer les modèles de notification
-        const templatesResponse = await axios.get('http://164.160.40.182:3001/api/notificationtemplates');
+        const templatesResponse = await axios.get(`${API_BASE_URL}/notificationtemplates`);
         setTemplates(templatesResponse.data);
 
         // Récupérer les préférences de notification
-        const preferencesResponse = await axios.get('http://164.160.40.182:3001/api/notificationpreferences');
+        const preferencesResponse = await axios.get(`${API_BASE_URL}/notificationpreferences`);
         setPreferences(preferencesResponse.data);
 
         // Récupérer les notifications
-        const notificationsResponse = await axios.get('http://164.160.40.182:3001/api/notifications');
+        const notificationsResponse = await axios.get(`${API_BASE_URL}/notifications`);
         setNotifications(notificationsResponse.data);
 
         // Récupérer la configuration des notifications
-        const configResponse = await axios.get('http://164.160.40.182:3001/api/notificationconfig');
+        const configResponse = await axios.get(`${API_BASE_URL}/notificationconfig`);
         setConfig(configResponse.data);
 
         setLoading(false);
@@ -184,7 +189,7 @@ const NotificationSettings: React.FC = () => {
 
     try {
       setLoading(true);
-      await axios.put('http://164.160.40.182:3001/api/notificationconfig', config);
+      await axios.put(`${API_BASE_URL}/notificationconfig`, config);
       setLoading(false);
       alert('Configuration enregistrée avec succès');
     } catch (error) {
@@ -242,7 +247,7 @@ const NotificationSettings: React.FC = () => {
       }
 
       // Appel API
-      const response = await axios.post('http://164.160.40.182:3001/api/notificationchannels', {
+      const response = await axios.post(`${API_BASE_URL}/notificationchannels`, {
         name: newChannel.name,
         type: newChannel.type,
         description: newChannel.description,
@@ -283,7 +288,7 @@ const NotificationSettings: React.FC = () => {
       }
 
       // Appel API
-      const response = await axios.post('http://164.160.40.182:3001/api/notificationtemplates', {
+      const response = await axios.post(`${API_BASE_URL}/notificationtemplates`, {
         name: newTemplate.name,
         event: newTemplate.event,
         subject: newTemplate.subject,

--- a/src/pages/settings/PerformanceSettings.tsx
+++ b/src/pages/settings/PerformanceSettings.tsx
@@ -10,6 +10,11 @@ import { useToast } from '../../components/ui/use-toast';
 import { ConfirmationDialog } from '../../components/ui/confirmation-dialog';
 import axios from 'axios';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+if (!API_BASE_URL) {
+  throw new Error('VITE_API_BASE_URL is required');
+}
+
 interface PerformanceConfig {
   id: string;
   cacheEnabled: boolean;
@@ -98,7 +103,7 @@ const PerformanceSettings: React.FC = () => {
         setLoading(true);
 
         // Récupérer la configuration des performances
-        const configResponse = await axios.get('http://164.160.40.182:3001/api/performanceconfig');
+        const configResponse = await axios.get(`${API_BASE_URL}/performanceconfig`);
         setConfig(configResponse.data);
 
         // Mettre à jour les états locaux
@@ -108,7 +113,7 @@ const PerformanceSettings: React.FC = () => {
         setQueryOptimization(configResponse.data.queryOptimization);
 
         // Récupérer les métriques de performance
-        const metricsResponse = await axios.get('http://164.160.40.182:3001/api/performancemetrics');
+        const metricsResponse = await axios.get(`${API_BASE_URL}/performancemetrics`);
         setMetrics(metricsResponse.data);
 
         setLoading(false);
@@ -123,7 +128,7 @@ const PerformanceSettings: React.FC = () => {
     // Mettre à jour les métriques toutes les 10 secondes
     const intervalId = setInterval(async () => {
       try {
-        const metricsResponse = await axios.get('http://164.160.40.182:3001/api/performancemetrics');
+        const metricsResponse = await axios.get(`${API_BASE_URL}/performancemetrics`);
         setMetrics(metricsResponse.data);
       } catch (error) {
         console.error('Erreur lors de la mise à jour des métriques:', error);
@@ -149,7 +154,7 @@ const PerformanceSettings: React.FC = () => {
         queryOptimization
       };
 
-      await axios.put('http://164.160.40.182:3001/api/performanceconfig', updatedConfig);
+      await axios.put(`${API_BASE_URL}/performanceconfig`, updatedConfig);
       setConfig(updatedConfig);
 
       setLoading(false);
@@ -180,7 +185,7 @@ const PerformanceSettings: React.FC = () => {
       setIsRunningDiagnostic(true);
 
       // Récupérer les métriques de performance
-      const metricsResponse = await axios.get('http://164.160.40.182:3001/api/performancemetrics');
+      const metricsResponse = await axios.get(`${API_BASE_URL}/performancemetrics`);
       setMetrics(metricsResponse.data);
 
       toast({

--- a/src/pages/settings/SequenceSettings.tsx
+++ b/src/pages/settings/SequenceSettings.tsx
@@ -9,6 +9,11 @@ import { useToast } from '../../components/ui/use-toast';
 import { ConfirmationDialog } from '../../components/ui/confirmation-dialog';
 import axios from 'axios';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+if (!API_BASE_URL) {
+  throw new Error('VITE_API_BASE_URL is required');
+}
+
 interface Sequence {
   id: string;
   name: string;
@@ -62,11 +67,11 @@ const SequenceSettings: React.FC = () => {
         setLoading(true);
 
         // Récupérer les séquences
-        const sequencesResponse = await axios.get('http://164.160.40.182:3001/api/sequences');
+        const sequencesResponse = await axios.get(`${API_BASE_URL}/sequences`);
         setSequences(sequencesResponse.data);
 
         // Récupérer la configuration des séquences
-        const configResponse = await axios.get('http://164.160.40.182:3001/api/sequenceconfig');
+        const configResponse = await axios.get(`${API_BASE_URL}/sequenceconfig`);
         setSequenceConfig(configResponse.data);
 
         setLoading(false);
@@ -91,7 +96,7 @@ const SequenceSettings: React.FC = () => {
 
       if (!sequenceConfig) return;
 
-      await axios.put('http://164.160.40.182:3001/api/sequenceconfig', sequenceConfig);
+      await axios.put(`${API_BASE_URL}/sequenceconfig`, sequenceConfig);
 
       toast({
         title: "Configuration sauvegardée",
@@ -123,7 +128,7 @@ const SequenceSettings: React.FC = () => {
     setIsResetting(true);
 
     try {
-      const response = await axios.post(`http://164.160.40.182:3001/api/sequences/${sequenceToReset.id}/reset`);
+      const response = await axios.post(`${API_BASE_URL}/sequences/${sequenceToReset.id}/reset`);
 
       // Mettre à jour la séquence dans le tableau
       setSequences(sequences.map(seq =>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,8 +1,14 @@
 import axios from 'axios';
 
+// Récupérer l'URL de base de l'API depuis les variables d'environnement
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+if (!apiBaseUrl) {
+  throw new Error('VITE_API_BASE_URL is required');
+}
+
 // Configuration de base d'axios
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api',
+  baseURL: apiBaseUrl,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -28,7 +28,10 @@ import {
   ShippingMethodsSettings
 } from '../types/settings.ts';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+if (!API_BASE_URL) {
+  throw new Error('VITE_API_BASE_URL is required');
+}
 
 /**
  * Service pour la gestion des paramètres

--- a/start.bat
+++ b/start.bat
@@ -148,7 +148,7 @@ call :log "success" "Application frontend démarrée avec succès."
 :: Afficher les informations d'accès
 call :log "info" "L'application est maintenant accessible aux adresses suivantes:"
 call :log "info" "- Frontend: http://localhost:8080"
-call :log "info" "- API: http://localhost:3001"
+call :log "info" "- API: %VITE_API_BASE_URL%"
 
 call :log "warning" "Pour arrêter l'application, fermez les fenêtres de commande ou appuyez sur Ctrl+C dans chaque fenêtre."
 

--- a/start.js
+++ b/start.js
@@ -207,7 +207,7 @@ async function main() {
     // Afficher les informations d'accès
     log('info', 'L\'application est maintenant accessible aux adresses suivantes:');
     log('info', '- Frontend: http://localhost:8080');
-    log('info', '- API: http://localhost:3001');
+    log('info', `- API: ${process.env.VITE_API_BASE_URL}`);
 
     log('warning', 'Appuyez sur Ctrl+C pour arrêter l\'application.');
 

--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,6 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration du serveur
-SERVER_IP="164.160.40.182"
 SERVER_MODE=${1:-"local"} # Par défaut en mode local, peut être "server" en argument
 
 # Fonction pour afficher les messages avec un préfixe
@@ -145,7 +144,7 @@ log "success" "Application frontend démarrée avec succès (PID: $FRONTEND_PID)
 # Afficher les informations d'accès
 log "info" "L'application est maintenant accessible aux adresses suivantes:"
 log "info" "- Frontend: http://localhost:8080"
-log "info" "- API: http://localhost:3001"
+log "info" "- API: ${VITE_API_BASE_URL}"
 
 log "warning" "Appuyez sur Ctrl+C pour arrêter l'application."
 

--- a/update-urls.sh
+++ b/update-urls.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-# Définir l'URL du serveur
-NEW_SERVER="164.160.40.182"
+# Met à jour la variable VITE_API_BASE_URL dans le fichier .env
+# Usage: ./update-urls.sh <nouveau_serveur>
 
-# Rechercher et remplacer les URLs codées en dur
-find ./src -type f -name "*.ts" -o -name "*.tsx" | xargs sed -i "s|http://localhost:3001|http://$NEW_SERVER:3001|g"
+NEW_SERVER="$1"
 
-# Mettre à jour les fichiers d'environnement
+if [ -z "$NEW_SERVER" ]; then
+  echo "Usage: $0 <nouveau_serveur>"
+  exit 1
+fi
+
 echo "VITE_API_BASE_URL=http://$NEW_SERVER:3001/api" > .env
+echo "VITE_API_BASE_URL mis à jour dans .env"
 
-echo "URLs mises à jour avec succès!"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,26 +5,31 @@ import path from "path";
 // import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3001',
-        changeOrigin: true,
-        secure: false,
+export default defineConfig(({ mode }) => {
+  const apiBaseUrl = process.env.VITE_API_BASE_URL;
+  const proxyTarget = apiBaseUrl ? new URL(apiBaseUrl).origin : "";
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
+      proxy: {
+        '/api': {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: false,
+        }
       }
-    }
-  },
-  plugins: [
-    react(),
-    // Désactivé temporairement en raison de problèmes de compatibilité ESM/CommonJS
-    // mode === 'development' && componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
     },
-  },
-}));
+    plugins: [
+      react(),
+      // Désactivé temporairement en raison de problèmes de compatibilité ESM/CommonJS
+      // mode === 'development' && componentTagger(),
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- remove hardcoded API URLs in services, settings pages, and start scripts in favor of VITE_API_BASE_URL
- simplify update-urls.sh to update `.env` only
- document API URL configuration via VITE_API_BASE_URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689de3c026ac832da69dba469ef473e5