### PR TITLE
Respect PORT environment variable in startup scripts

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -83,10 +83,14 @@ if %ERRORLEVEL% equ 0 (
   timeout /t 2 >nul
 )
 
-call :check_port 3001
+set "API_PORT=%PORT%"
+if "%API_PORT%"=="" set "API_PORT=3001"
+set "PORT=%API_PORT%"
+
+call :check_port %API_PORT%
 if %ERRORLEVEL% equ 0 (
-  call :log "warning" "Un processus est déjà en cours d'exécution sur le port 3001. Tentative d'arrêt..."
-  for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":3001"') do (
+  call :log "warning" "Un processus est déjà en cours d'exécution sur le port %API_PORT%. Tentative d'arrêt..."
+  for /f "tokens=5" %%a in ('netstat -ano ^| findstr ":%API_PORT%"') do (
     taskkill /F /PID %%a >nul 2>nul
   )
   timeout /t 2 >nul
@@ -120,7 +124,7 @@ call :log "info" "Attente du démarrage du serveur API..."
 timeout /t 5 >nul
 
 :: Vérifier si le serveur est en cours d'exécution
-call :check_port 3001
+call :check_port %API_PORT%
 if %ERRORLEVEL% neq 0 (
   call :log "error" "Le serveur API n'a pas pu démarrer. Veuillez vérifier les erreurs dans la fenêtre du serveur."
   exit /b 1
@@ -148,7 +152,7 @@ call :log "success" "Application frontend démarrée avec succès."
 :: Afficher les informations d'accès
 call :log "info" "L'application est maintenant accessible aux adresses suivantes:"
 call :log "info" "- Frontend: http://localhost:8080"
-call :log "info" "- API: http://localhost:3001"
+call :log "info" "- API: http://localhost:%API_PORT%"
 
 call :log "warning" "Pour arrêter l'application, fermez les fenêtres de commande ou appuyez sur Ctrl+C dans chaque fenêtre."
 

--- a/start.js
+++ b/start.js
@@ -123,9 +123,11 @@ async function main() {
   try {
     log('info', 'Démarrage de l\'application avec migrations...');
 
+    const apiPort = process.env.PORT || 3001;
+
     // Vérifier si les ports sont déjà utilisés
     const port8080InUse = await isPortInUse(8080);
-    const port3001InUse = await isPortInUse(3001);
+    const portApiInUse = await isPortInUse(apiPort);
 
     if (port8080InUse) {
       log('warning', 'Le port 8080 est déjà utilisé. Tentative d\'arrêt du processus...');
@@ -134,9 +136,9 @@ async function main() {
       await new Promise(resolve => setTimeout(resolve, 2000));
     }
 
-    if (port3001InUse) {
-      log('warning', 'Le port 3001 est déjà utilisé. Tentative d\'arrêt du processus...');
-      await killProcessOnPort(3001);
+    if (portApiInUse) {
+      log('warning', `Le port ${apiPort} est déjà utilisé. Tentative d\'arrêt du processus...`);
+      await killProcessOnPort(apiPort);
       // Attendre un peu pour s'assurer que le port est libéré
       await new Promise(resolve => setTimeout(resolve, 2000));
     }
@@ -180,7 +182,7 @@ async function main() {
     await new Promise(resolve => setTimeout(resolve, 5000));
 
     // Vérifier si le serveur est en cours d'exécution
-    if (!await isPortInUse(3001)) {
+    if (!await isPortInUse(apiPort)) {
       log('error', 'Le serveur API n\'a pas pu démarrer. Veuillez vérifier les erreurs ci-dessus.');
       return;
     }
@@ -207,7 +209,7 @@ async function main() {
     // Afficher les informations d'accès
     log('info', 'L\'application est maintenant accessible aux adresses suivantes:');
     log('info', '- Frontend: http://localhost:8080');
-    log('info', '- API: http://localhost:3001');
+    log('info', `- API: http://localhost:${apiPort}`);
 
     log('warning', 'Appuyez sur Ctrl+C pour arrêter l\'application.');
 

--- a/start.sh
+++ b/start.sh
@@ -76,6 +76,9 @@ check_port() {
   fi
 }
 
+API_PORT=${PORT:-3001}
+export PORT=$API_PORT
+
 # Arrêter les processus existants si nécessaire
 if check_port 8080; then
   log "warning" "Un processus est déjà en cours d'exécution sur le port 8080. Tentative d'arrêt..."
@@ -83,9 +86,9 @@ if check_port 8080; then
   sleep 2
 fi
 
-if check_port 3001; then
-  log "warning" "Un processus est déjà en cours d'exécution sur le port 3001. Tentative d'arrêt..."
-  kill $(lsof -t -i:3001) 2>/dev/null || true
+if check_port "$API_PORT"; then
+  log "warning" "Un processus est déjà en cours d'exécution sur le port $API_PORT. Tentative d'arrêt..."
+  kill $(lsof -t -i:$API_PORT) 2>/dev/null || true
   sleep 2
 fi
 
@@ -145,7 +148,7 @@ log "success" "Application frontend démarrée avec succès (PID: $FRONTEND_PID)
 # Afficher les informations d'accès
 log "info" "L'application est maintenant accessible aux adresses suivantes:"
 log "info" "- Frontend: http://localhost:8080"
-log "info" "- API: http://localhost:3001"
+log "info" "- API: http://localhost:$API_PORT"
 
 log "warning" "Appuyez sur Ctrl+C pour arrêter l'application."
 


### PR DESCRIPTION
## Summary
- allow configuring API port via `process.env.PORT` in `start.js`
- use `PORT` environment variable with default 3001 in `start.sh` and `start.bat`

## Testing
- `PORT=4000 node start.js` *(fails: Cannot find module 'dotenv')*
- `PORT=4000 bash start.sh` *(fails: Cannot find module '/workspace/entidr/node_modules/cliui/build/index.cjs')*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689de3c05b18832d86b6fd0d6e20490c