### PR TITLE
fix: remove duplicate API_BASE_URL constant in ModulesSettings

### DIFF
--- a/src/components/settings/ModulesSettings.tsx
+++ b/src/components/settings/ModulesSettings.tsx
@@ -27,14 +27,6 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Loader2, Trash2, Power, RefreshCw } from 'lucide-react';
 import { Module } from '../../types/module';
 
-import { API_BASE_URL } from '../../config/api';
-
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-if (!API_BASE_URL) {
-  throw new Error('VITE_API_BASE_URL is required');
-}
-
 // Utilise l'URL de base de l'API définie dans les variables d'environnement, avec un
 // repli local identique au reste du projet pour éviter toute adresse codée en dur.
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000/api';


### PR DESCRIPTION
## Summary
- remove duplicate API_BASE_URL declarations in ModulesSettings
- keep local constant with fallback to localhost

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot use import statement outside a module)


------
https://chatgpt.com/codex/tasks/task_e_689e0a92182c832da5199a94f897bbbe