### PR TITLE
feat: add BPMN module specification

### DIFF
--- a/addons/bpmn/README.md
+++ b/addons/bpmn/README.md
@@ -1,0 +1,77 @@
+# Module BPMN - Cahier des charges
+
+## 1. Contexte & objectifs
+
+Permettre aux équipes métier et techniques de modéliser, exécuter et superviser des processus métiers via le standard **BPMN 2.0** sans écrire de code. Le module doit offrir un moteur d'exécution robuste, traçable et facilement intégrable avec le système d'information (paiements, signature électronique, notifications, etc.).
+
+**Objectifs clés**
+- Modélisation visuelle conforme BPMN 2.0 avec bibliothèque de modèles.
+- Exécution fiable (états, timers, messages, erreurs, compensation).
+- Automatisation via règles, formulaires et intégrations.
+- Gouvernance : versioning, cycle de vie, audit, rôles et permissions.
+- Pilotage : indicateurs KPI, SLA, analytics et tableaux de bord.
+
+## 2. Périmètre
+
+**In scope** : éditeur BPMN, moteur d'exécution, formulaires, connecteurs, notifications, génération de documents, signature électronique, paiements optionnels, import/export BPMN, API et webhooks, monitoring, audit, gestion des versions et environnements.
+
+**Out of scope** : RPA desktop, ETL volumineux (délégué à des services tiers).
+
+## 3. Acteurs & rôles (RBAC)
+
+| Rôle | Responsabilités principales |
+|------|-----------------------------|
+| SuperAdmin | configuration globale, tenants, quotas, sécurité |
+| Administrateur Fonctionnel | gouvernance des processus, rôles, catalogues, SLA |
+| Concepteur | crée/modifie diagrammes, formulaires, règles, connecteurs |
+| Éditeur | modifie métadonnées, contenus descriptifs, templates |
+| Validateur | relit et approuve avant publication |
+| Opérateur | déclenche et suit les instances, gère les tâches humaines |
+| Auditeur | accès lecture aux journaux et pistes d'audit |
+| Utilisateur final | soumet des demandes via formulaires |
+
+## 4. Cas d'usage représentatifs
+
+- **Demande d'identité** : formulaire → vérification des pièces → validation multi-niveaux → génération PDF → notification → archivage.
+- **Permis de construire** : instruction avec passerelles (complet/incomplet), paiements, avis techniques parallèles, délais et escalades.
+- **Aide sociale** : collecte justificatifs, scoring (DMN), commission, décision, versement, suivi.
+
+## 5. Fonctionnalités détaillées
+
+### 5.1 Modélisation (Éditeur BPMN)
+- Palette BPMN 2.0 : événements, tâches (user, service, script), passerelles XOR/OR/AND, sous-processus, timers, messages, signaux, compensation, erreurs et escalades.
+- Lanes/pools, objets de données, artefacts.
+- Validation syntaxique et sémantique.
+- Gestion des propriétés par élément : assignee, SLA, scripts, mappages I/O.
+- Form builder lié aux tâches humaines.
+- Règles DMN ou expressions (JavaScript/JSONata) pour le routage.
+- Versioning, import/export BPMN 2.0, bibliothèque de templates.
+
+### 5.2 Formulaires & données
+- Form builder avec champs textes, nombres, dates, pièces jointes, validations et conditionnels.
+- Variables de processus, masquage PII, chiffrement sélectif.
+- Pré-remplissage via contexte utilisateur ou APIs externes.
+- Gestion des états de formulaires et pièces jointes.
+
+### 5.3 Exécution (Moteur BPMN)
+- Cycle de vie des instances : Created → Running → Suspended → Completed → Canceled → Failed.
+- Gestion des jobs avec retries et idempotence.
+- Timers (delays, cron, échéances SLA, escalades).
+- Handlers pour tâches utilisateur, service (HTTP, gRPC, SQL, message bus), script JS sandbox, call activity.
+- Événements message/signal/erreur/escalade, limites d'interruption.
+- Parallélisme via passerelles et synchronisation.
+- Transactions & compensation.
+
+### 5.4 Intégrations & connecteurs
+- Connecteurs natifs : HTTP/REST, SOAP, GraphQL, emails, SMS, stockage objet, bases de données, solutions de paiement (Stripe, PayGate), e-signature (DocuSign), queues (Kafka, NATS), SSO.
+- Catalogue extensible et SDK.
+- Coffre-fort pour secrets et credentials.
+- Mappage de données avec transformations JSONata.
+
+## 6. Critères d'acceptation
+- Conformité avec BPMN 2.0 pour l'import/export.
+- Exécution fiable avec suivi des états et des timers.
+- Traçabilité complète : audit, logs, métriques.
+- RBAC appliqué sur toutes les opérations sensibles.
+- APIs documentées et stables pour intégration externe.
+

--- a/addons/bpmn/index.ts
+++ b/addons/bpmn/index.ts
@@ -1,0 +1,16 @@
+// Exporter les routes (aucune pour le moment)
+export { default as routes } from './routes';
+
+// Exporter le manifeste
+export { default as manifest } from './manifest';
+
+// Aucun composant spécifique pour l'instant
+export const Components = {};
+
+export function initialize() {
+  // Code d'initialisation du module BPMN
+}
+
+export function cleanup() {
+  // Code de nettoyage du module BPMN
+}

--- a/addons/bpmn/manifest.ts
+++ b/addons/bpmn/manifest.ts
@@ -1,0 +1,112 @@
+import { AddonManifest } from '../../src/types/addon';
+
+const manifest: AddonManifest = {
+  // Métadonnées de base
+  name: 'bpmn',
+  version: '1.0.0',
+  displayName: 'BPMN',
+  summary: 'Modélisation et exécution de processus BPMN 2.0',
+  description: 'Module pour créer, publier et piloter des workflows métiers via BPMN 2.0',
+
+  // Configuration
+  application: true,
+  autoInstall: false,
+  installable: true,
+
+  // Routes définies par l'addon
+  routes: [],
+
+  // Modèles de données
+  models: [
+    {
+      name: 'bpmn.process',
+      displayName: 'Processus',
+      fields: [
+        { name: 'name', type: 'string', required: true, label: 'Nom' },
+        { name: 'version', type: 'string', required: true, label: 'Version' },
+        { name: 'definition', type: 'string', required: true, label: 'Définition BPMN XML' },
+        { name: 'status', type: 'string', required: true, label: 'Statut', default: 'draft' }
+      ]
+    },
+    {
+      name: 'bpmn.instance',
+      displayName: 'Instance',
+      fields: [
+        { name: 'process_id', type: 'many2one', required: true, label: 'Processus', relation: 'bpmn.process' },
+        { name: 'status', type: 'string', required: true, label: 'Statut', default: 'created' },
+        { name: 'start_date', type: 'datetime', required: false, label: 'Date de début' },
+        { name: 'end_date', type: 'datetime', required: false, label: 'Date de fin' }
+      ]
+    },
+    {
+      name: 'bpmn.task',
+      displayName: 'Tâche',
+      fields: [
+        { name: 'instance_id', type: 'many2one', required: true, label: 'Instance', relation: 'bpmn.instance' },
+        { name: 'name', type: 'string', required: true, label: 'Nom' },
+        { name: 'type', type: 'string', required: true, label: 'Type' },
+        { name: 'assignee_id', type: 'many2one', required: false, label: 'Assigné à', relation: 'hr.employee' },
+        { name: 'due_date', type: 'date', required: false, label: 'Échéance' },
+        { name: 'status', type: 'string', required: true, label: 'Statut', default: 'pending' }
+      ]
+    },
+    {
+      name: 'bpmn.connector',
+      displayName: 'Connecteur',
+      fields: [
+        { name: 'name', type: 'string', required: true, label: 'Nom' },
+        { name: 'type', type: 'string', required: true, label: 'Type' },
+        { name: 'config', type: 'string', required: false, label: 'Configuration' }
+      ]
+    },
+    {
+      name: 'bpmn.form',
+      displayName: 'Formulaire',
+      fields: [
+        { name: 'name', type: 'string', required: true, label: 'Nom' },
+        { name: 'schema', type: 'string', required: true, label: 'Schéma JSON' },
+        { name: 'public', type: 'boolean', required: true, label: 'Public', default: false }
+      ]
+    }
+  ],
+
+  // Menus définis par l'addon
+  menus: [
+    {
+      id: 'menu_bpmn_root',
+      name: 'BPMN',
+      sequence: 60,
+      route: '/bpmn',
+      icon: 'Workflow'
+    },
+    {
+      id: 'menu_bpmn_processes',
+      name: 'Processus',
+      sequence: 10,
+      route: '/bpmn/processes',
+      parent: 'menu_bpmn_root',
+      icon: 'CircuitBoard'
+    },
+    {
+      id: 'menu_bpmn_instances',
+      name: 'Instances',
+      sequence: 20,
+      route: '/bpmn/instances',
+      parent: 'menu_bpmn_root',
+      icon: 'PlayCircle'
+    },
+    {
+      id: 'menu_bpmn_connectors',
+      name: 'Connecteurs',
+      sequence: 30,
+      route: '/bpmn/connectors',
+      parent: 'menu_bpmn_root',
+      icon: 'Cable'
+    }
+  ],
+
+  // Dépendances
+  dependencies: []
+};
+
+export default manifest;

--- a/addons/bpmn/routes.tsx
+++ b/addons/bpmn/routes.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { RouteDefinition } from '../../src/types/addon';
+
+// Aucune route pour le moment, placeholder
+const routes: RouteDefinition[] = [];
+
+export default routes;


### PR DESCRIPTION
## Summary
- add BPMN module manifest and skeleton
- document BPMN module requirements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_689e46eb0994832db9355f3883711095